### PR TITLE
Fixed Issues Related to Certain Input Sizes Failing/Decode close-to-zero

### DIFF
--- a/src/benchmarks/bfv/palisade_bfv_matmult_cipherbatchaxis_benchmark.cpp
+++ b/src/benchmarks/bfv/palisade_bfv_matmult_cipherbatchaxis_benchmark.cpp
@@ -118,14 +118,6 @@ MatMultCipherBatchAxisBenchmark::MatMultCipherBatchAxisBenchmark(PalisadeEngine 
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd)
-    {
-        std::stringstream ss;
-        ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "
-           << (pmd) << ") x (" << (pmd) << " x m).";
-        throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS(ss.str()),
-                                         HEBENCH_ECODE_INVALID_ARGS);
-    } // end if
 
     m_p_context = PalisadeContext::createBFVContext(pmd, mult_depth, coeff_bits, lbcrypto::HEStd_128_classic);
     m_p_context->EvalMultKeyGen();

--- a/src/benchmarks/bfv/palisade_bfv_matmulteip_benchmark.cpp
+++ b/src/benchmarks/bfv/palisade_bfv_matmulteip_benchmark.cpp
@@ -118,11 +118,11 @@ MatMultEIPBenchmark::MatMultEIPBenchmark(PalisadeEngine &engine,
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd)
+    if (m_w_params.cols_M0 > pmd - 1)
     {
         std::stringstream ss;
         ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "
-           << (pmd) << ") x (" << (pmd) << " x m).";
+           << (pmd - 1) << ") x (" << (pmd - 1) << " x m).";
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS(ss.str()),
                                          HEBENCH_ECODE_INVALID_ARGS);
     } // end if
@@ -223,7 +223,7 @@ MatMultEIPBenchmark::doMatMultEIP(const std::vector<lbcrypto::Ciphertext<lbcrypt
             try
             {
                 if (!p_ex)
-                    retval[i][j] = m_p_context->context()->EvalInnerProduct(M0[i], M1_T[j], m_w_params.cols_M0);
+                    retval[i][j] = m_p_context->context()->EvalInnerProduct(M0[i], M1_T[j], m_p_context->getSlotCount());
             }
             catch (...)
             {

--- a/src/benchmarks/bfv/palisade_bfv_matmultrow_benchmark.cpp
+++ b/src/benchmarks/bfv/palisade_bfv_matmultrow_benchmark.cpp
@@ -120,11 +120,11 @@ MatMultRowBenchmark::MatMultRowBenchmark(PalisadeEngine &engine,
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd)
+
+    if (m_w_params.cols_M0 > (pmd - 1) || m_w_params.cols_M0 * m_w_params.cols_M1 > (pmd))
     {
         std::stringstream ss;
-        ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "
-           << (pmd) << ") x (" << (pmd) << " x m).";
+        ss << "Invalid workload parameters. This workload only supports matrices of dimensions (a x b) x (b x c) where 'b' is at max " << (pmd - 1) << " and b * c is at max " << (pmd) << " (e.g. PolyModulusDegree).";
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS(ss.str()),
                                          HEBENCH_ECODE_INVALID_ARGS);
     } // end if

--- a/src/benchmarks/bfv/palisade_bfv_matmultval_benchmark.cpp
+++ b/src/benchmarks/bfv/palisade_bfv_matmultval_benchmark.cpp
@@ -118,11 +118,11 @@ MatMultValBenchmark::MatMultValBenchmark(PalisadeEngine &engine,
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd)
+    if (m_w_params.cols_M0 > pmd - 1)
     {
         std::stringstream ss;
         ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "
-           << (pmd) << ") x (" << (pmd) << " x m).";
+           << (pmd - 1) << ") x (" << (pmd - 1) << " x m).";
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS(ss.str()),
                                          HEBENCH_ECODE_INVALID_ARGS);
     } // end if
@@ -224,7 +224,7 @@ MatMultValBenchmark::doMatMultVal(const std::vector<lbcrypto::Ciphertext<lbcrypt
             {
                 if (!p_ex)
                     retval[i][j] =
-                        m_p_context->context()->EvalSum(m_p_context->context()->EvalMult(M0[i], M1_T[j]), m_w_params.cols_M0);
+                        m_p_context->context()->EvalSum(m_p_context->context()->EvalMult(M0[i], M1_T[j]), m_p_context->getSlotCount());
             }
             catch (...)
             {

--- a/src/benchmarks/ckks/palisade_ckks_eltwiseadd_pc_benchmark.cpp
+++ b/src/benchmarks/ckks/palisade_ckks_eltwiseadd_pc_benchmark.cpp
@@ -114,13 +114,11 @@ EltwiseAddPlainCipherBenchmark::EltwiseAddPlainCipherBenchmark(PalisadeEngine &e
     hebench::cpp::WorkloadParams::EltwiseAdd w_params(bench_params);
 
     if (w_params.n <= 0
-        || w_params.n - 1 > pmd / 2)
+        || w_params.n > pmd / 2)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Invalid workload parameters. This workload only supports vectors up to size " + std::to_string(pmd / 2) + "."),
                                          HEBENCH_ECODE_INVALID_ARGS);
 
     m_p_context = PalisadeContext::createCKKSContext(pmd, mult_depth, scale_bits, w_params.n);
-    //    m_p_context->printContextInfo(std::cout);
-    //    std::cout << std::endl;
 }
 
 EltwiseAddPlainCipherBenchmark::~EltwiseAddPlainCipherBenchmark()

--- a/src/benchmarks/ckks/palisade_ckks_matmult_cipherbatchaxis_benchmark.cpp
+++ b/src/benchmarks/ckks/palisade_ckks_matmult_cipherbatchaxis_benchmark.cpp
@@ -119,7 +119,7 @@ MatMultCipherBatchAxisBenchmark::MatMultCipherBatchAxisBenchmark(PalisadeEngine 
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd / 2)
+    if (m_w_params.cols_M0 > pmd / 2)
     {
         std::stringstream ss;
         ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "
@@ -128,12 +128,8 @@ MatMultCipherBatchAxisBenchmark::MatMultCipherBatchAxisBenchmark(PalisadeEngine 
                                          HEBENCH_ECODE_INVALID_ARGS);
     } // end if
 
-    //    std::vector<int32_t> vec(m_w_params.cols_M0);
-    //    std::iota(std::begin(vec), std::end(vec), 1);
     m_p_context = PalisadeContext::createCKKSContext(pmd, mult_depth, scale_bits, lbcrypto::HEStd_128_classic, m_w_params.cols_M0);
     m_p_context->EvalMultKeyGen();
-    //    m_p_context->EvalAtIndexKeyGen(vec);
-    //    m_p_context->EvalSumKeyGen();
 }
 
 MatMultCipherBatchAxisBenchmark::~MatMultCipherBatchAxisBenchmark()

--- a/src/benchmarks/ckks/palisade_ckks_matmulteip_benchmark.cpp
+++ b/src/benchmarks/ckks/palisade_ckks_matmulteip_benchmark.cpp
@@ -119,7 +119,7 @@ MatMultEIPBenchmark::MatMultEIPBenchmark(PalisadeEngine &engine,
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd / 2)
+    if (m_w_params.cols_M0 > pmd / 2)
     {
         std::stringstream ss;
         ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "

--- a/src/benchmarks/ckks/palisade_ckks_matmultrow_benchmark.cpp
+++ b/src/benchmarks/ckks/palisade_ckks_matmultrow_benchmark.cpp
@@ -121,11 +121,11 @@ MatMultRowBenchmark::MatMultRowBenchmark(PalisadeEngine &engine,
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd)
+
+    if (m_w_params.cols_M0 > (pmd / 2) || m_w_params.cols_M0 * m_w_params.cols_M1 > (pmd / 2))
     {
         std::stringstream ss;
-        ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "
-           << (pmd) << ") x (" << (pmd) << " x m).";
+        ss << "Invalid workload parameters. This workload only supports matrices of dimensions (a x b) x (b x c) where 'b' and b * c is at max " << (pmd / 2) << " (e.g. PolyModulusDegree / 2).";
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS(ss.str()),
                                          HEBENCH_ECODE_INVALID_ARGS);
     } // end if

--- a/src/benchmarks/ckks/palisade_ckks_matmultval_benchmark.cpp
+++ b/src/benchmarks/ckks/palisade_ckks_matmultval_benchmark.cpp
@@ -119,7 +119,7 @@ MatMultValBenchmark::MatMultValBenchmark(PalisadeEngine &engine,
     if (m_w_params.rows_M0 <= 0 || m_w_params.cols_M0 <= 0 || m_w_params.cols_M1 <= 0)
         throw hebench::cpp::HEBenchError(HEBERROR_MSG_CLASS("Matrix dimensions must be greater than 0."),
                                          HEBENCH_ECODE_INVALID_ARGS);
-    if (m_w_params.cols_M0 - 1 > pmd / 2)
+    if (m_w_params.cols_M0 > pmd / 2)
     {
         std::stringstream ss;
         ss << "Invalid workload parameters. This workload only supports matrices of dimensions (n x "


### PR DESCRIPTION
## Proposed changes

- Fixing Issues dealing with various input sizes either causing incorrect answers or not being caught in backend code (and pushing down to 3rd-party library code)
- Close-to-zero check present in each ckks benchmark

## Types of changes

What types of changes does your code introduce to the HEBench PALISADE Reference Backend?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/hebench/backend-cpu-palisade/blob/main/CONTRIBUTING.md) doc
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
